### PR TITLE
Fixing unmarshaling crash when restoring result receiver

### DIFF
--- a/library/src/main/java/com/telly/groundy/CallbacksManager.java
+++ b/library/src/main/java/com/telly/groundy/CallbacksManager.java
@@ -73,12 +73,8 @@ public final class CallbacksManager {
 
     if (callbackHandlers != null) {
       for (TaskHandler proxyTask : new ArrayList<TaskHandler>(callbacksManager.proxyTasks)) {
-        if (proxyTask.taskAlreadyEnded()) {
-          callbacksManager.proxyTasks.remove(proxyTask);
-        } else {
-          proxyTask.clearCallbacks();
-          proxyTask.appendCallbacks(callbackHandlers);
-        }
+        proxyTask.clearCallbacks();
+        proxyTask.appendCallbacks(callbackHandlers);
       }
     }
     return callbacksManager;
@@ -92,12 +88,8 @@ public final class CallbacksManager {
   public void linkCallbacks(Object... callbackHandlers) {
     if (callbackHandlers != null) {
       for (TaskHandler proxyTask : new ArrayList<TaskHandler>(proxyTasks)) {
-        if (proxyTask.taskAlreadyEnded()) {
-          proxyTasks.remove(proxyTask);
-        } else {
-          proxyTask.clearCallbacks();
-          proxyTask.appendCallbacks(callbackHandlers);
-        }
+        proxyTask.clearCallbacks();
+        proxyTask.appendCallbacks(callbackHandlers);
       }
     }
   }

--- a/library/src/main/java/com/telly/groundy/Groundy.java
+++ b/library/src/main/java/com/telly/groundy/Groundy.java
@@ -29,7 +29,7 @@ import android.os.Bundle;
 import android.os.Looper;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.os.ResultReceiver;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 
@@ -360,10 +360,13 @@ public final class Groundy implements Parcelable {
     @Override public Groundy createFromParcel(Parcel source) {
       Class groundyTask = (Class) source.readSerializable();
       long id = source.readLong();
+      boolean hadReceiver = source.readByte() == 1;
 
       //noinspection unchecked
       Groundy groundy = new Groundy(groundyTask, id);
-      groundy.mReceiver = source.readParcelable(ResultReceiver.class.getClassLoader());
+      if (hadReceiver) {
+        groundy.mReceiver = source.readParcelable(CallbacksReceiver.class.getClassLoader());
+      }
       groundy.mArgs.putAll(source.readBundle());
       groundy.mGroupId = source.readInt();
       groundy.mAlreadyProcessed = source.readByte() == 1;
@@ -385,7 +388,10 @@ public final class Groundy implements Parcelable {
   @Override public void writeToParcel(Parcel dest, int flags) {
     dest.writeSerializable(mGroundyTask);
     dest.writeLong(mId);
-    dest.writeParcelable(mReceiver, flags);
+    dest.writeByte((byte) (mReceiver == null ? 0 : 1));
+    if (mReceiver != null) {
+      dest.writeParcelable(mReceiver, flags);
+    }
     dest.writeBundle(mArgs);
     dest.writeInt(mGroupId);
     dest.writeByte((byte) (mAlreadyProcessed ? 1 : 0));

--- a/library/src/main/java/com/telly/groundy/GroundyManager.java
+++ b/library/src/main/java/com/telly/groundy/GroundyManager.java
@@ -168,7 +168,7 @@ public final class GroundyManager {
     private final Class<? extends GroundyService> mGroundyServiceClass;
 
     GroundyServiceConnection(Context context, Class<? extends GroundyService> groundyServiceClass) {
-      mContext = context;
+      mContext = context.getApplicationContext();
       mGroundyServiceClass = groundyServiceClass;
     }
 

--- a/library/src/main/java/com/telly/groundy/TaskHandler.java
+++ b/library/src/main/java/com/telly/groundy/TaskHandler.java
@@ -57,7 +57,4 @@ public interface TaskHandler extends Parcelable {
    * @param handlers the callback handlers to remove
    */
   void removeCallbacks(Object... handlers);
-
-  /** @return true if the value was already ended. */
-  boolean taskAlreadyEnded();
 }

--- a/library/src/main/java/com/telly/groundy/TaskHandlerImpl.java
+++ b/library/src/main/java/com/telly/groundy/TaskHandlerImpl.java
@@ -29,7 +29,6 @@ import android.os.Parcel;
 class TaskHandlerImpl implements TaskHandler {
 
   private final Groundy mGroundy;
-  private boolean mTaskEnded = false;
 
   TaskHandlerImpl(Groundy groundy) {
     mGroundy = groundy;
@@ -37,12 +36,8 @@ class TaskHandlerImpl implements TaskHandler {
 
   @Override public void cancel(Context context, int reason,
       GroundyManager.SingleCancelListener cancelListener) {
-    if (!mTaskEnded) {
-      GroundyManager.cancelTaskById(context, mGroundy.getId(), reason, cancelListener,
-          mGroundy.getGroundyServiceClass());
-    } else if (cancelListener != null) {
-      cancelListener.onCancelResult(mGroundy.getId(), GroundyService.COULD_NOT_CANCEL);
-    }
+    GroundyManager.cancelTaskById(context, mGroundy.getId(), reason, cancelListener,
+        mGroundy.getGroundyServiceClass());
   }
 
   @Override public void clearCallbacks() {
@@ -50,10 +45,6 @@ class TaskHandlerImpl implements TaskHandler {
     if (callbacksReceiver != null) {
       callbacksReceiver.clearHandlers();
     }
-  }
-
-  @Override public boolean taskAlreadyEnded() {
-    return mTaskEnded;
   }
 
   @Override public void appendCallbacks(Object... handlers) {
@@ -72,10 +63,6 @@ class TaskHandlerImpl implements TaskHandler {
 
   @Override public long getTaskId() {
     return mGroundy.getId();
-  }
-
-  void onTaskEnded() {
-    mTaskEnded = true;
   }
 
   @SuppressWarnings("UnusedDeclaration")


### PR DESCRIPTION
There are two possible causes for this error, both plausible and fixed by this commit:
1. Since I was using `ResultReceiver.class.getClassLoader()` instead of `CallbacksReceiver.class.getClassLoader()`, there is a chance that `Parcelable` instance was using the default class loader instead of the app one.
2. `Parcelable` implementation might fail if the object being restored was `null`. In order to avoid such cases, we are not saving the result receiver if it's `null` (using a `boolean` flag control such cases).

@eveliotc Since I was not able to reproduce this on the phone, and Genymotion is still not working for me, I'd really appreciate if you could test and see whether the bug was actually fixed.
