### PR TITLE
Follow redirects even when the response was not empty

### DIFF
--- a/library/src/main/java/com/telly/groundy/util/DownloadUtils.java
+++ b/library/src/main/java/com/telly/groundy/util/DownloadUtils.java
@@ -107,14 +107,9 @@ public final class DownloadUtils {
     URL url = new URL(fromUrl);
     URLConnection urlConnection = url.openConnection();
     urlConnection.connect();
-    int contentLength = urlConnection.getContentLength();
-    if (contentLength == -1) {
-      fromUrl = urlConnection.getHeaderField("Location");
-      if (fromUrl == null) {
-        throw new IOException(
-            "No content or redirect found for URL " + url + " with " + redirect + " redirects.");
-      }
-      downloadFileHandleRedirect(context, fromUrl, toFile, redirect + 1, listener);
+    String redirectTarget = urlConnection.getHeaderField("Location");
+    if (redirectTarget != null) {
+      downloadFileHandleRedirect(context, redirectTarget, toFile, redirect + 1, listener);
       return;
     }
     InputStream input = urlConnection.getInputStream();


### PR DESCRIPTION
The existance and/or size content length header field is not really indicative of a redirect. The content length header may be empty for a non-redirected request as well as there may be some content returned for a redirected request.

With this PR, only the existance of the location header field is used to determine if the request is being redirected.
